### PR TITLE
forward host header based on resolved path

### DIFF
--- a/utils/utils.js
+++ b/utils/utils.js
@@ -9,6 +9,7 @@ var util = require('util');
 var _ = require('underscore');
 var parse = require('co-body');
 var multipart = require('./multipart');
+var hostRegex = /[^\/]+(\w)\//; //regex to extract request host
 
 /**
  * Export several useful method
@@ -117,6 +118,9 @@ exports.configRequestOptions = function(self, options) {
     headers: self.header,
     qs: !!options.keep_query_string ? self.query : {}
   };
+
+  // forward host on request
+  opts.headers.host = hostRegex.test(opts.url) ? opts.url.match(hostRegex)[0].replace('/', '') : opts.host;
 
   switch (true) {
     case _.isEmpty(self.request.body):


### PR DESCRIPTION
Some servers need the right host header to be set in requests in order to resolve virtual hosts.